### PR TITLE
Fixed condition where non paywalled pages from Zeit would still redirect

### DIFF
--- a/others/Spiegel redirect to Archive.today.user.js
+++ b/others/Spiegel redirect to Archive.today.user.js
@@ -207,7 +207,7 @@
       document.location.hostname.indexOf('zeit.de') !== -1 &&
       document.location.pathname.length > 1 && (
         document.querySelector('.zplus-badge__link') ||
-        document.getElementById('paywall') ||
+        document.getElementById('paywall').childElementCount != 0 ||
         ('k5aMeta' in window && window.k5aMeta.paywall === 'hard')
       )
     ) {


### PR DESCRIPTION
When opening pages like f.ex.: https://www.zeit.de/gesellschaft/zeitgeschehen/2024-05/antisemitismusbeauftragter-verurteilung-proteste-israel-esc there appears to be a paywall element in the dom, however this is empty. Still that page will be falsely redirected. Checking if this element is empty helps