### PR TITLE
add Timeout to http Request

### DIFF
--- a/others/Paywall redirect to Archive.today.user.js
+++ b/others/Paywall redirect to Archive.today.user.js
@@ -70,10 +70,12 @@
       GM.xmlHttpRequest({
         url: `https://${hostname}/`,
         method: 'GET',
+        timeout: 5000,
         headers: {
           Range: 'bytes=0-63'
         },
         onload: onResponse,
+        ontimeout: onResponse,
         onerror: onResponse
       })
     })


### PR DESCRIPTION
with this timeout (hardcoded 5s), the probe of archive-domains will skip dead domains way faster.

