### PR TITLE
Refactor to site array for more easy setup

### DIFF
--- a/others/Paywall redirect to Archive.today.user.js
+++ b/others/Paywall redirect to Archive.today.user.js
@@ -350,7 +350,7 @@
           if (typeof site.action === 'function') {
             site.action(document, window)
           } else {
-            archivePage(document.location.href)
+            await archivePage(document.location.href)
           }
 
           break


### PR DESCRIPTION
# Changes

I refactored the script to use a `sites` array for easier configuration and to reduce the amount of `if/else` logic. 19451f5

# Site Entry

```javascript
{
  hostname: 'spiegel',
  check: (doc, win) => {},
  waitOnFirstRun: true, // optional; defaults to false
  action: (doc, win) => {}, // optional; defaults to `archivePage`
}
```

# Fixes

- **tagesspiegel**: Corrected typo from `#paywal` to `#paywall` 39a5879
- **archive**:
  - Improved the detection of archived pages that still show a paywall. Previously, it only checked for Spiegel’s `[data-area="paywall"]`, which excluded other sites. 76b41e8 
  - ~This check might still be optimized by extracting the archived URL from `#HEADER form input[name=q]` and matching it against `site.hostname`~  
    _Implemented in commit: 61097d3_

# Site Added

- **heise.de** support added (commit: 526621e)

# Known Issues

- **faz.net**: Selectors are not reliably detecting paywall markers.
- **sz-magazin.sueddeutsche.de**: Redirects to `sueddeutsche.de/magazin`, possibly obsolete.
- **nytimes.com**: Always triggers redirection from the main/every page because `iframe[src*="captcha"]` is always present.
- we should find an other way for the `history` link because this link is localized in German as `Versionsgeschichte`:
```js
const historyLink = Array.from(doc.querySelectorAll('#HEADER form a'))
              .find(e => e.textContent.includes('history'))
```

# Setup

- macOS Sonoma 14.5
- Chrome 137.0.x
