### PR TITLE
add history entry for current url

### DIFF
--- a/others/Paywall redirect to Archive.today.user.js
+++ b/others/Paywall redirect to Archive.today.user.js
@@ -174,7 +174,13 @@
     }
 
     if (workingHostname) {
-      document.location.href = `https://${workingHostname}/?run=1&url=${encodeURIComponent(url)}`
+      let redirectUrl = `https://${workingHostname}/?run=1&url=${encodeURIComponent(url)}`
+      // push current url to document history
+      document.location.assign(url)
+      // wait that the url is pushed to history
+      setTimeout(() => {
+        document.location.assign(redirectUrl);
+      }, 100);
     } else {
       window.setTimeout(() => {
         showSpinner(`<a href="https://archive.today/?run=1&url=${encodeURIComponent(url)}">Try archive.today</a>`)


### PR DESCRIPTION
# Changes:

- push current url as new history entry



# Problem solved

- when I open a link with archive.is (open a new tab OR send an url from iOS to macOS with hyperduck app)
- and when a captcha is needed to check 
- and the tab goes to suspend mode
- then clicking on this tab do not show the url anymore and the original url is gone
- with this change I can retrieve the origianal url by hitting cmd+shift+R to reload the archive blank page
- then in the history behind the back button the original url shows up


# Workaround

- I know this is a workaround - maybe there is a better way to get the original url restored while going the suspended tab 


Results when many things comes togeter is this empty archive form in every tab I forget to solve the captcha:

![Bildschirmfoto 2025-07-04 um 11 23 35](https://github.com/user-attachments/assets/b344bfee-416f-4b3c-b4f0-11ed296f95d4)

